### PR TITLE
Add %in% analogue

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 useDynLib(fastmatch, C_fmatch = fmatch, C_ctapply = ctapply, C_coalesce = coalesce, C_append = append, mk_hash, get_table, get_values)
-export(fmatch, fmatch.hash, ctapply, coalesce)
+export(fmatch, fmatch.hash, ctapply, coalesce, "%fin%")
 export(mk.hash, append.hash, map.values)
 S3method(print, match.hash)
 S3method(levels, fasthash)

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@
     o	added coalesce() - fast way of grouping unique values into
 	contiguous groups (in linear time).
 
+    o	added %fin% - a fast version of %in%
+
     o	fastmatch now supports long vectors. Note that the hash
 	function is the same as in R and thus it uses at most 32-bits,
 	hence long vectors can be used, but they must have less than

--- a/R/fastmatch.R
+++ b/R/fastmatch.R
@@ -3,3 +3,6 @@ fmatch <- function(x, table, nomatch = NA_integer_, incomparables = NULL)
 
 fmatch.hash <- function(x, table, nomatch = NA_integer_, incomparables = NULL)
   .Call(C_fmatch, x, table, nomatch, incomparables, TRUE)
+
+`%fin%` <- function (x, table)
+  fmatch(x, table, nomatch = 0L) > 0L

--- a/man/fmatch.Rd
+++ b/man/fmatch.Rd
@@ -1,5 +1,6 @@
 \name{fmatch}
 \alias{fmatch}
+\alias{\%fin\%}
 \alias{fmatch.hash}
 \alias{fastmatch}
 \title{
@@ -21,10 +22,14 @@ to \code{match} with a warning.
 object with the hash table attached instead of the result, so it can be
 used to create a table object in cases where direct modification is
 not possible.
+
+\code{\%fin\%} is a version of the built-in \code{\link{\%in\%}} function
+that uses \code{fmatch} instead of \code{\link{match}}().
 }
 \usage{
 fmatch(x, table, nomatch = NA_integer_, incomparables = NULL)
 fmatch.hash(x, table, nomatch = NA_integer_, incomparables = NULL)
+x \%fin\% table
 }
 \arguments{
   \item{x}{values to be matched}
@@ -59,6 +64,10 @@ fmatch.hash(x, table, nomatch = NA_integer_, incomparables = NULL)
 
   \code{fmatch.hash}: \code{table}, possibly coerced to match the type
   of \code{x}, with the hash table attached.
+
+  \code{\%fin\%}: A logical vector the same length as \code{x} - see
+  \code{\link{\%in\%}} for details.
+
 }
 %\references{
 %}
@@ -134,3 +143,4 @@ identical(base::match(s, y), fmatch(s, y))
 identical(base::match(4L, 1:3, nomatch=0), fmatch(4L, 1:3, nomatch=0))
 }
 \keyword{manip}
+\keyword{logic}


### PR DESCRIPTION
`fmatch` aims to be a drop-in replacement for `match`, and `%in%` is just
a simple wrapper around `match`, so adding a fastmatch analogue to `%in%`
is straight-forward.

Add '\keyword{logic}' to be consistent with base/man/match.Rd.

Fixes #2.
