### PR TITLE
Add SystemRequirements to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,4 @@ License: GPL-2
 Depends: R (>= 2.3.0)
 URL: https://www.rforge.net/fastmatch
 BugReports: https://github.com/s-u/fastmatch/issues/
+SystemRequirements: C99, GNU Atomic Library (libatomic)


### PR DESCRIPTION
When working in https://github.com/emscripten-forge/recipes/pull/4305 and cross-compiling `fastmatch` to Wasm, the cross-compilation failed with the message

```
$BUILD_PREFIX/bin/wasm-opt: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

This PR adds `SystemRequirements` to `DESCRIPTION` for clarification to future users.